### PR TITLE
Allow extractor-js to follow redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 extractor-js
 ============
 
+# FORK NOTE!
+
+This is a fork of [https://github.com/rsdoiel/extractor-js](Extractor), but adds the ability to follow 302 redirects by plugging in [https://npmjs.org/package/follow-redirects](follow-redirects) module.
+
 # Before you dive in
 
 When I originally wrote extractor-js there wasn't allot of libraries that did what I needed at the time.

--- a/extractor.js
+++ b/extractor.js
@@ -19,7 +19,7 @@
 var	url = require('url'),
 	fs = require('fs'),
 	path = require('path'),
-	http = require('http'),
+	http = require('follow-redirects').http,
 	https = require('https'),
 	querystring = require('querystring'),
 	jsdom = require('jsdom').jsdom;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"npm" : ">= 1"
 	},
 	"dependencies" : {
-		"jsdom" : ">= 0.2.10"
+		"jsdom" : ">= 0.2.10",
+                "follow-redirects" : "0.0.3"
 	},
 	"scripts" : {
 		"test" : "node extractor_test.js"


### PR DESCRIPTION
If the page your are spidering as a 302, it is convenient for extractor to follow the 302/301. Using the "follow-redirects" package, it is very simple to do.
